### PR TITLE
[WIP] Atom mapping for concerted reactions 

### DIFF
--- a/src/mrnet/core/mol_entry.py
+++ b/src/mrnet/core/mol_entry.py
@@ -7,7 +7,6 @@ import numpy as np
 from typing import Any, Dict, List, Optional, Tuple
 import networkx as nx
 from monty.json import MSONable
-from monty.dev import deprecated
 from pymatgen.core.structure import Molecule
 from pymatgen.analysis.fragmenter import metal_edge_extender
 from pymatgen.analysis.graphs import MoleculeGraph, MolGraphSplitError
@@ -82,15 +81,11 @@ class MoleculeEntry(MSONable):
                 else:
                     self.mol_graph = MoleculeGraph.from_dict(self.mol_doc["mol_graph"])
             else:
-                mol_graph = MoleculeGraph.with_local_env_strategy(
-                    molecule, OpenBabelNN()
-                )
+                mol_graph = MoleculeGraph.with_local_env_strategy(molecule, OpenBabelNN())
                 self.mol_graph = metal_edge_extender(mol_graph)
         else:
             if self.mol_graph is None:
-                mol_graph = MoleculeGraph.with_local_env_strategy(
-                    molecule, OpenBabelNN()
-                )
+                mol_graph = MoleculeGraph.with_local_env_strategy(molecule, OpenBabelNN())
                 self.mol_graph = metal_edge_extender(mol_graph)
 
     @classmethod
@@ -178,46 +173,36 @@ class MoleculeEntry(MSONable):
         return [str(s) for s in self.mol_graph.molecule.species]
 
     @property
-    def num_atoms(self) -> int:
-        return len(self.mol_graph.molecule)
-
-    @property
-    @deprecated(message="`edges` is replaced by `bonds`. This will be removed shortly.")
-    def edges(self) -> List[Tuple[int, int]]:
-        return self.bonds
-
-    @property
     def bonds(self) -> List[Tuple[int, int]]:
         return [tuple(sorted(e)) for e in self.graph.edges()]
 
     @property
-    @deprecated(
-        message="`Nbonds` is replaced by `num_bonds`. This will be removed shortly."
-    )
-    def Nbonds(self) -> int:
-        return self.num_bonds
+    def num_atoms(self) -> int:
+        return len(self.mol_graph.molecule)
 
     @property
     def num_bonds(self) -> int:
         return len(self.bonds)
 
+    #
+    # @property
+    # @deprecated(message="`edges` is replaced by `bonds`. This will be removed shortly.")
+    # def edges(self) -> List[Tuple[int, int]]:
+    #     return self.bonds
+
     @property
     def coords(self) -> np.ndarray:
         return self.mol_graph.molecule.cart_coords
 
-    @deprecated(
-        message="`free_energy(temp=<float>)` is replaced by "
-        "get_free_energy(temperature=<float>)`. This will be removed shortly."
-    )
-    def free_energy(self, temp=298.15) -> float:
-        return self.get_free_energy(temp)
-
-    def get_free_energy(self, temp: float = 298.15) -> float:
+    def get_free_energy(self, temperature: float = 298.15) -> float:
+        """
+        Get the free energy at the give temperature.
+        """
         if self.enthalpy is not None and self.entropy is not None:
             return (
                 self.energy * 27.21139
                 + 0.0433641 * self.enthalpy
-                - temp * self.entropy * 0.0000433641
+                - temperature * self.entropy * 0.0000433641
             )
         else:
             return None
@@ -326,7 +311,7 @@ class MoleculeEntry(MSONable):
     def __repr__(self):
         output = [
             "MoleculeEntry {} - {} - E{} - C{}".format(
-                self.entry_id, self.formula, self.Nbonds, self.charge
+                self.entry_id, self.formula, self.num_bonds, self.charge
             ),
             "Energy = {:.4f} Hartree".format(self.uncorrected_energy),
             "Correction = {:.4f} Hartree".format(self.correction),

--- a/src/mrnet/network/reaction_network.py
+++ b/src/mrnet/network/reaction_network.py
@@ -190,9 +190,7 @@ class ReactionPath(MSONable):
                             if PR_b2 is None:
                                 if PR_b in pool_modified:
                                     if PR_b in list(min_cost.keys()):
-                                        class_instance.cost = (
-                                            class_instance.cost - min_cost[PR_b]
-                                        )
+                                        class_instance.cost = class_instance.cost - min_cost[PR_b]
                                     else:
                                         pass
                                     pool.remove(a)
@@ -204,22 +202,13 @@ class ReactionPath(MSONable):
                                     if PR_b in old_solved_PRs:
                                         class_instance.solved_prereqs.append(PR_b)
                                         class_instance.all_prereqs.append(PR_b)
-                                        PR_b_byproducts = PR_byproduct_dict[PR_b][
-                                            "byproducts"
-                                        ]
+                                        PR_b_byproducts = PR_byproduct_dict[PR_b]["byproducts"]
                                         start = int(PR_byproduct_dict[PR_b]["start"])
                                         if a in PR_b_byproducts:
                                             # print("path replacement happenning")
-                                            new_path_piece1 = actualPRs[PR_b][
-                                                start
-                                            ].path
+                                            new_path_piece1 = actualPRs[PR_b][start].path
                                             new_path_piece2 = [
-                                                str(PR_b)
-                                                + "+"
-                                                + "PR_"
-                                                + str(a)
-                                                + ","
-                                                + str(c)
+                                                str(PR_b) + "+" + "PR_" + str(a) + "," + str(c)
                                             ]
                                             if concerted:
                                                 new_path_piece2 = [
@@ -234,14 +223,10 @@ class ReactionPath(MSONable):
                                                 ]
                                             new_path_piece3 = path[ii + 1 : :]
                                             new_path = (
-                                                new_path_piece1
-                                                + new_path_piece2
-                                                + new_path_piece3
+                                                new_path_piece1 + new_path_piece2 + new_path_piece3
                                             )
                                             # print(path, new_path_piece1, new_path_piece2,new_path_piece3 )
-                                            assert (
-                                                c == path[ii + 1] or d == path[ii + 1]
-                                            )
+                                            assert c == path[ii + 1] or d == path[ii + 1]
                                             if new_path_piece2[0] not in graph.nodes:
                                                 pool.remove(a)
                                                 pool = pool + PR_b_byproducts
@@ -274,22 +259,15 @@ class ReactionPath(MSONable):
                             else:  # nodes with 2 PRs
                                 if PR_b in pool_modified and PR_b2 in pool_modified:
                                     # print("!!")
-                                    class_instance.cost = (
-                                        class_instance.cost - min_cost[PR_b]
-                                    )
-                                    class_instance.cost = (
-                                        class_instance.cost - min_cost[PR_b2]
-                                    )
+                                    class_instance.cost = class_instance.cost - min_cost[PR_b]
+                                    class_instance.cost = class_instance.cost - min_cost[PR_b2]
                                     pool.remove(a)
                                     pool.remove(PR_b)
                                     pool.remove(PR_b2)
                                     pool.append(c)
                                     pool.append(d)
 
-                                elif (
-                                    PR_b not in old_solved_PRs
-                                    and PR_b2 not in old_solved_PRs
-                                ):
+                                elif PR_b not in old_solved_PRs and PR_b2 not in old_solved_PRs:
                                     class_instance.unsolved_prereqs.append(PR_b)
                                     class_instance.unsolved_prereqs.append(PR_b2)
                                     class_instance.all_prereqs.append(PR_b)
@@ -298,14 +276,8 @@ class ReactionPath(MSONable):
                                     pool.append(c)
                                     pool.append(d)
 
-                                elif (
-                                    PR_b not in pool_modified
-                                    and PR_b2 not in pool_modified
-                                ):
-                                    if (
-                                        PR_b in old_solved_PRs
-                                        and PR_b2 in old_solved_PRs
-                                    ):
+                                elif PR_b not in pool_modified and PR_b2 not in pool_modified:
+                                    if PR_b in old_solved_PRs and PR_b2 in old_solved_PRs:
                                         pool.remove(a)
                                         pool.append(c)
                                         pool.append(d)
@@ -313,25 +285,16 @@ class ReactionPath(MSONable):
                                         class_instance.solved_prereqs.append(PR_b2)
                                         class_instance.all_prereqs.append(PR_b)
                                         class_instance.all_prereqs.append(PR_b2)
-                                        PR_b_byproducts = PR_byproduct_dict[PR_b][
-                                            "byproducts"
-                                        ]
-                                        PR_b2_byproducts = PR_byproduct_dict[PR_b2][
-                                            "byproducts"
-                                        ]
+                                        PR_b_byproducts = PR_byproduct_dict[PR_b]["byproducts"]
+                                        PR_b2_byproducts = PR_byproduct_dict[PR_b2]["byproducts"]
                                         pool = pool + PR_b_byproducts + PR_b2_byproducts
 
-                                    elif (
-                                        PR_b not in old_solved_PRs
-                                        or PR_b2 not in old_solved_PRs
-                                    ):
+                                    elif PR_b not in old_solved_PRs or PR_b2 not in old_solved_PRs:
                                         if PR_b not in old_solved_PRs:
                                             class_instance.unsolved_prereqs.append(PR_b)
                                             class_instance.all_prereqs.append(PR_b)
                                         elif PR_b2 not in old_solved_PRs:
-                                            class_instance.unsolved_prereqs.append(
-                                                PR_b2
-                                            )
+                                            class_instance.unsolved_prereqs.append(PR_b2)
                                             class_instance.all_prereqs.append(PR_b2)
                                         pool.remove(a)
                                         pool.append(c)
@@ -352,12 +315,8 @@ class ReactionPath(MSONable):
                                         pool.remove(PR_in_pool)
 
                                     elif PR_not_in_pool in old_solved_PRs:
-                                        class_instance.unsolved_prereqs.append(
-                                            PR_not_in_pool
-                                        )
-                                        class_instance.all_prereqs.append(
-                                            PR_not_in_pool
-                                        )
+                                        class_instance.unsolved_prereqs.append(PR_not_in_pool)
+                                        class_instance.all_prereqs.append(PR_not_in_pool)
                                     pool.remove(a)
                                     pool.append(c)
                                     pool.append(d)
@@ -479,16 +438,12 @@ class ReactionPath(MSONable):
                             graph.nodes[step]["free_energy"]
                         )
 
-                    class_instance.overall_free_energy_change += graph.nodes[step][
-                        "free_energy"
-                    ]
+                    class_instance.overall_free_energy_change += graph.nodes[step]["free_energy"]
 
                     if class_instance.description == "":
                         class_instance.description += graph.nodes[step]["rxn_type"]
                     else:
-                        class_instance.description += (
-                            ", " + graph.nodes[step]["rxn_type"]
-                        )
+                        class_instance.description += ", " + graph.nodes[step]["rxn_type"]
 
                     if class_instance.hardest_step is None:
                         class_instance.hardest_step = step
@@ -503,9 +458,9 @@ class ReactionPath(MSONable):
             if class_instance.hardest_step is None:
                 class_instance.hardest_step_deltaG = None
             else:
-                class_instance.hardest_step_deltaG = graph.nodes[
-                    class_instance.hardest_step
-                ]["free_energy"]
+                class_instance.hardest_step_deltaG = graph.nodes[class_instance.hardest_step][
+                    "free_energy"
+                ]
 
         class_instance.just_path_bp = []
         for ii, step in enumerate(class_instance.path):
@@ -646,13 +601,13 @@ class ReactionNetwork(MSONable):
             return x.formula
 
         def get_Nbonds(x):
-            return x.Nbonds
+            return x.num_bonds
 
         def get_charge(x):
             return x.charge
 
         def get_free_energy(x):
-            return x.free_energy(temp=temperature)
+            return x.get_free_energy(temperature)
 
         sorted_entries_0 = sorted(connected_entries, key=get_formula)
         for k1, g1 in itertools.groupby(sorted_entries_0, get_formula):
@@ -671,12 +626,12 @@ class ReactionNetwork(MSONable):
                                 if entry.mol_graph.isomorphic_to(Uentry.mol_graph):
                                     isomorphic_found = True
                                     if (
-                                        entry.free_energy() is not None
-                                        and Uentry.free_energy() is not None
+                                        entry.get_free_energy() is not None
+                                        and Uentry.get_free_energy() is not None
                                     ):
-                                        if entry.free_energy(
-                                            temp=temperature
-                                        ) < Uentry.free_energy(temp=temperature):
+                                        if entry.get_free_energy(
+                                            temperature
+                                        ) < Uentry.get_free_energy(temperature):
                                             unique[ii] = entry
                                     elif entry.free_energy() is not None:
                                         unique[ii] = entry
@@ -965,9 +920,7 @@ class ReactionNetwork(MSONable):
                         cost_from_start[PR][start] = PRs[PR][start].cost
                         if PRs[PR][start].cost < min_cost[PR]:
                             min_cost[PR] = PRs[PR][start].cost
-                            self.PR_byproducts[PR]["byproducts"] = PRs[PR][
-                                start
-                            ].byproducts
+                            self.PR_byproducts[PR]["byproducts"] = PRs[PR][start].byproducts
                             self.PR_byproducts[PR]["start"] = start
                 for start in starts:
                     if start not in cost_from_start[PR]:
@@ -1038,9 +991,7 @@ class ReactionNetwork(MSONable):
             nodes.pop(-1)
         return nodes, PR, Reactants
 
-    def find_path_cost(
-        self, starts, weight, old_solved_PRs, cost_from_start, min_cost, PRs
-    ):
+    def find_path_cost(self, starts, weight, old_solved_PRs, cost_from_start, min_cost, PRs):
         """
             A method to characterize the path to all the PRs. Characterize by
             determining if the path exist or not, and
@@ -1103,17 +1054,11 @@ class ReactionNetwork(MSONable):
                             if step.count("+") == 1:
                                 nodes = nodes + [step.split("+")[0]]
                                 Reactants.append(int(step.split("+")[0]))
-                                PR.append(
-                                    int(
-                                        step.split("+")[1].split("PR_")[1].split(",")[0]
-                                    )
-                                )
+                                PR.append(int(step.split("+")[1].split("PR_")[1].split(",")[0]))
                                 if node in PR:
                                     if node not in wrong_paths[start]:
                                         wrong_paths[start].append(int(node))
-                                nodes = nodes + step.split("+")[1].split("PR_")[
-                                    1
-                                ].split(",")
+                                nodes = nodes + step.split("+")[1].split("PR_")[1].split(",")
                             elif step.count("+") == 2:
                                 nodes = nodes + [step.split(",")[0].split("+PR_")[0]]
                                 Reactants.append(step.split(",")[0].split("+PR_")[0])
@@ -1160,10 +1105,7 @@ class ReactionNetwork(MSONable):
             for node in wrong_paths[start]:
                 fixed_paths[start][node] = {}
                 try:
-                    (
-                        length,
-                        dij_path,
-                    ) = nx.algorithms.simple_paths._bidirectional_dijkstra(
+                    (length, dij_path,) = nx.algorithms.simple_paths._bidirectional_dijkstra(
                         self.graph,
                         source=hash(start),
                         target=hash(node),
@@ -1187,15 +1129,9 @@ class ReactionNetwork(MSONable):
                     self.unsolvable_PRs_per_start[start].append(node)
                     pass
                 else:
-                    dist_and_path[start][node]["cost"] = fixed_paths[start][node][
-                        "cost"
-                    ]
-                    dist_and_path[start][node]["path"] = fixed_paths[start][node][
-                        "path"
-                    ]
-                    nodes, PR, reactant = self.parse_path(
-                        dist_and_path[start][node]["path"]
-                    )
+                    dist_and_path[start][node]["cost"] = fixed_paths[start][node]["cost"]
+                    dist_and_path[start][node]["path"] = fixed_paths[start][node]["path"]
+                    nodes, PR, reactant = self.parse_path(dist_and_path[start][node]["path"])
                     dist_and_path[start][node]["all_nodes"] = nodes
                     dist_and_path[start][node]["PRs"] = PR
                     dist_and_path[start][node]["reactant"] = reactant
@@ -1231,9 +1167,7 @@ class ReactionNetwork(MSONable):
                             PRs[node][start] = path_class
                         if path_class.cost < min_cost[node]:
                             min_cost[node] = path_class.cost
-                            self.PR_byproducts[node][
-                                "byproducts"
-                            ] = path_class.byproducts
+                            self.PR_byproducts[node]["byproducts"] = path_class.byproducts
                             self.PR_byproducts[node]["start"] = start
 
         return PRs, cost_from_start, min_cost
@@ -1347,10 +1281,7 @@ class ReactionNetwork(MSONable):
                             PR_paths=PRs,
                         )
                         PRs[PR][start] = path_dict_class
-                        if (
-                            abs(path_dict_class.cost - path_dict_class.pure_cost)
-                            > 0.0001
-                        ):
+                        if abs(path_dict_class.cost - path_dict_class.pure_cost) > 0.0001:
                             print(
                                 "WARNING: cost mismatch for PR",
                                 PR,
@@ -1443,9 +1374,7 @@ class ReactionNetwork(MSONable):
         valid_graph = self.find_or_remove_bad_nodes([target], remove_nodes=True)
         valid_graph.remove_nodes_from(PRs)
 
-        return nx.shortest_simple_paths(
-            valid_graph, hash(start), hash(target), weight=self.weight
-        )
+        return nx.shortest_simple_paths(valid_graph, hash(start), hash(target), weight=self.weight)
 
     def find_paths(self, starts, target, weight, num_paths=10, ignorenode=[]):  # -> ??
         """
@@ -1515,9 +1444,7 @@ class ReactionNetwork(MSONable):
                             PR_byproduct_dict=self.PR_byproducts,
                             PR_paths=self.PRs,
                         )
-                        heapq.heappush(
-                            my_heapq, (path_dict_class2.cost, next(c), path_dict_class2)
-                        )
+                        heapq.heappush(my_heapq, (path_dict_class2.cost, next(c), path_dict_class2))
         except Exception:
             print("ind", ind)
         top_path_list = []
@@ -1554,19 +1481,11 @@ class ReactionNetwork(MSONable):
 
         pruned_PRs = {}
         for PR_node in RN_pr_solved.PR_byproducts:
-            if (
-                RN_pr_solved.PRs[PR_node] != {}
-                and RN_pr_solved.PR_byproducts[PR_node] != {}
-            ):
+            if RN_pr_solved.PRs[PR_node] != {} and RN_pr_solved.PR_byproducts[PR_node] != {}:
                 min_start = RN_pr_solved.PR_byproducts[PR_node]["start"]
-                if (
-                    RN_pr_solved.PRs[PR_node][min_start].overall_free_energy_change
-                    <= cutoff
-                ):
+                if RN_pr_solved.PRs[PR_node][min_start].overall_free_energy_change <= cutoff:
                     pruned_PRs[PR_node] = {}
-                    pruned_PRs[PR_node][min_start] = RN_pr_solved.PRs[PR_node][
-                        min_start
-                    ]
+                    pruned_PRs[PR_node][min_start] = RN_pr_solved.PRs[PR_node][min_start]
 
         nodes_to_keep = []
         for PR_node in pruned_PRs:
@@ -1634,9 +1553,7 @@ class ReactionNetwork(MSONable):
                 for out_node in out_nodes:
                     for in_node in in_nodes:
                         rxn1_dG = RN_pr_solved.graph.nodes[in_node]["free_energy"]
-                        total_dG = (
-                            rxn1_dG + RN_pr_solved.graph.nodes[out_node]["free_energy"]
-                        )
+                        total_dG = rxn1_dG + RN_pr_solved.graph.nodes[out_node]["free_energy"]
                         if rxn1_dG > 0 and total_dG < 0:
                             # if flag:
                             if "PR" in out_node and "PR" in in_node:
@@ -1705,12 +1622,8 @@ class ReactionNetwork(MSONable):
                                         )
                             elif "PR" in in_node and "PR" not in out_node:
                                 if "+" in out_node:
-                                    p1 = list(
-                                        map(int, out_node.split(",")[1].split("+"))
-                                    )[0]
-                                    p2 = list(
-                                        map(int, out_node.split(",")[1].split("+"))
-                                    )[1]
+                                    p1 = list(map(int, out_node.split(",")[1].split("+")))[0]
+                                    p2 = list(map(int, out_node.split(",")[1].split("+")))[1]
                                 else:
                                     p2 = out_node.split(",")[1]
                                     p1 = None
@@ -1728,10 +1641,14 @@ class ReactionNetwork(MSONable):
                                     product1 = int(p2)
                                     product2 = int(p1)
                                     glist = [reactant1, reactant2, product1, product2]
-                                if set(glist).issubset(set(mols_to_keep)) and {
-                                    reactant1,
-                                    reactant2,
-                                } != {product1, product2}:
+                                if (
+                                    set(glist).issubset(set(mols_to_keep))
+                                    and {
+                                        reactant1,
+                                        reactant2,
+                                    }
+                                    != {product1, product2}
+                                ):
                                     count = count + 1
                                     # print(glist, set(glist).issubset(set(mols_to_keep)))
                                     reactions.append(
@@ -1742,13 +1659,9 @@ class ReactionNetwork(MSONable):
                                         )
                                     )
                             elif "PR" not in in_node and "PR" in out_node:
-                                if (
-                                    "+" in in_node
-                                ):  # want this: 2441,2426''2426+PR_148,3669'
+                                if "+" in in_node:  # want this: 2441,2426''2426+PR_148,3669'
                                     start = in_node.split(",")[0]
-                                    p1 = list(
-                                        map(int, in_node.split(",")[1].split("+"))
-                                    )
+                                    p1 = list(map(int, in_node.split(",")[1].split("+")))
                                     p1.remove(node)
                                     p1 = p1[0]
                                 else:
@@ -1770,10 +1683,14 @@ class ReactionNetwork(MSONable):
                                     product2 = int(p2)
                                     glist = [reactant1, reactant2, product1, product2]
 
-                                if set(glist).issubset(set(mols_to_keep)) and {
-                                    reactant1,
-                                    reactant2,
-                                } != {product1, product2}:
+                                if (
+                                    set(glist).issubset(set(mols_to_keep))
+                                    and {
+                                        reactant1,
+                                        reactant2,
+                                    }
+                                    != {product1, product2}
+                                ):
                                     count = count + 1
                                     # print(glist, set(glist).issubset(set(mols_to_keep)))
                                     reactions.append(
@@ -1846,9 +1763,7 @@ class ReactionNetwork(MSONable):
                 else:
                     assert int(reaction[1][1]) in pruned_network_build.graph.nodes
                 if not new_node:
-                    reactant_0 = full_network_pr_solved.entries_list[
-                        int(reaction[0][0])
-                    ]
+                    reactant_0 = full_network_pr_solved.entries_list[int(reaction[0][0])]
                     PR = full_network_pr_solved.entries_list[int(reaction[0][1])]
                     product_0 = full_network_pr_solved.entries_list[int(reaction[1][0])]
                     product_1 = full_network_pr_solved.entries_list[int(reaction[1][1])]
@@ -1856,35 +1771,25 @@ class ReactionNetwork(MSONable):
                     cr.electron_free_energy = -2.15
                     g = cr.graph_representation()
                     for node in list(g.nodes):
-                        if (
-                            not isinstance(node, int)
-                            and g.nodes[node]["free_energy"] > 0
-                        ):
+                        if not isinstance(node, int) and g.nodes[node]["free_energy"] > 0:
                             g.remove_node(node)
                     pruned_network_build.add_reaction(g)
                     c3 = c3 + 1
                 elif new_node:
-                    reactant_0 = full_network_pr_solved.entries_list[
-                        int(reaction[0][0])
-                    ]
+                    reactant_0 = full_network_pr_solved.entries_list[int(reaction[0][0])]
                     PR = full_network_pr_solved.entries_list[int(reaction[0][1])]
                     product_0 = full_network_pr_solved.entries_list[int(reaction[1][0])]
                     cr = ConcertedReaction([reactant_0, PR], [product_0])
                     cr.electron_free_energy = -2.15
                     g = cr.graph_representation()
                     for node in list(g.nodes):
-                        if (
-                            not isinstance(node, int)
-                            and g.nodes[node]["free_energy"] > 0
-                        ):
+                        if not isinstance(node, int) and g.nodes[node]["free_energy"] > 0:
                             g.remove_node(node)
                     pruned_network_build.add_reaction(g)
                     c3 = c3 + 1
 
         pruned_network_build.PR_record = pruned_network_build.build_PR_record()
-        pruned_network_build.Reactant_record = (
-            pruned_network_build.build_reactant_record()
-        )
+        pruned_network_build.Reactant_record = pruned_network_build.build_reactant_record()
         print("add_concerted_rxns end", time.time())
         return pruned_network_build
 


### PR DESCRIPTION
We have atom mapping for elementary reactions now, but I haven't added atom mapping for concerted reactions yet. 

There are basically two methods:

- Use elementary reactions and take advantage of the reaction network structure to quickly find out elementary reactions connected to each other. 
e.g. for two elementary reactions  A->B+C, C->D with atom mapping, we can get the atom mapping for A->B+D easily. 
Note, this requires the intermediate C exists, so this is not a full solution. But, maybe OK for now?

- Use the integer linear optimization algorithm used by Xiaowei to extract concerted reactions (but slow due to the combinatorial nature). 

Will explore both...