### PR TITLE
better rate constant computation

### DIFF
--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -184,7 +184,7 @@ class SerializedReactionNetwork:
                 if dG < 0:
                     rate = max_rate
                 else:
-                    rate = max_rate * math.exp(- dG / kT)
+                    rate = max_rate * math.exp(-dG / kT)
 
             else:
                 if dG < 0:
@@ -703,7 +703,7 @@ def run(
     number_of_threads: int = 4,
     number_of_steps: int = 200,
     number_of_simulations: int = 1000,
-    constant_barrier=None
+    constant_barrier=None,
 ) -> SimulationAnalyser:
     """
     procedure which takes a list of molecule entries + initial state and runs
@@ -718,7 +718,7 @@ def run(
         network_folder,
         param_folder,
         logging=False,
-        constant_barrier=constant_barrier
+        constant_barrier=constant_barrier,
     )
 
     rnsd.serialize()

--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -83,8 +83,6 @@ class SerializedReactionNetwork:
         self.network_folder = network_folder
         self.param_folder = param_folder
         self.logging = logging
-        self.boltzman_constant = boltzman_constant
-        self.planck_constant = planck_constant
         self.temperature = temperature
         self.constant_barrier = constant_barrier
 
@@ -190,6 +188,9 @@ class SerializedReactionNetwork:
                 else:
                     rate = max_rate * math.exp(-dG / kT)
 
+            # if all rates are being set using a constant_barrier as in this formula,
+            # then the constant barrier will not actually affect the simulation. It
+            # becomes important when rates are being manually set.
             else:
                 if dG < 0:
                     rate = max_rate * math.exp(-self.constant_barrier / kT)

--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -62,9 +62,9 @@ class SerializedReactionNetwork:
         network_folder: str,
         param_folder: str,
         logging: bool = False,
-        boltzman_constant = 8.617e-5, # eV/K
-        planck_constant = 6.582e-16, # eV s
-        temperature = 298.15, # K
+        boltzman_constant=8.617e-5,  # eV/K
+        planck_constant=6.582e-16,  # eV s
+        temperature=298.15,  # K
         constant_barrier=None,
     ):
 
@@ -190,7 +190,7 @@ class SerializedReactionNetwork:
                 if dG < 0:
                     rate = math.exp(-self.constant_barrier / kT)
                 else:
-                    rate = math.exp(-(self.constant_barrier + dG)/ kT)
+                    rate = math.exp(-(self.constant_barrier + dG) / kT)
 
             reaction["rate_constant"] = rate
 

--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -48,6 +48,7 @@ def find_mol_entry_from_xyz_and_charge(mol_entries, xyz_file_path, charge):
     else:
         return None
 
+
 # TODO: once there is a central place for these, import from there
 boltzman_constant = 8.617e-5  # eV/K
 planck_constant = 6.582e-16  # eV s

--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -48,6 +48,11 @@ def find_mol_entry_from_xyz_and_charge(mol_entries, xyz_file_path, charge):
     else:
         return None
 
+# TODO: once there is a central place for these, import from there
+boltzman_constant = 8.617e-5  # eV/K
+planck_constant = 6.582e-16  # eV s
+room_temp = 298.15  # K
+
 
 class SerializedReactionNetwork:
     """
@@ -62,10 +67,8 @@ class SerializedReactionNetwork:
         network_folder: str,
         param_folder: str,
         logging: bool = False,
-        boltzman_constant=8.617e-5,  # eV/K
-        planck_constant=6.582e-16,  # eV s
-        temperature=298.15,  # K
-        constant_barrier=None,
+        temperature=room_temp,
+        constant_barrier=None
     ):
 
         if isinstance(reaction_network, ReactionGenerator):
@@ -177,8 +180,8 @@ class SerializedReactionNetwork:
         for reaction in index_to_reaction:
 
             dG = reaction["free_energy"]
-            kT = self.boltzman_constant * self.temperature
-            max_rate = kT / self.planck_constant
+            kT = boltzman_constant * self.temperature
+            max_rate = kT / planck_constant
 
             if self.constant_barrier is None:
                 if dG < 0:

--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -192,9 +192,9 @@ class SerializedReactionNetwork:
 
             else:
                 if dG < 0:
-                    rate = math.exp(-self.constant_barrier / kT)
+                    rate = max_rate * math.exp(-self.constant_barrier / kT)
                 else:
-                    rate = math.exp(-(self.constant_barrier + dG) / kT)
+                    rate = max_rate * math.exp(-(self.constant_barrier + dG) / kT)
 
             reaction["rate_constant"] = rate
 

--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -69,7 +69,7 @@ class SerializedReactionNetwork:
         param_folder: str,
         logging: bool = False,
         temperature=room_temp,
-        constant_barrier=None
+        constant_barrier=None,
     ):
 
         if isinstance(reaction_network, ReactionGenerator):

--- a/tests/stochastic/test_rnmc.py
+++ b/tests/stochastic/test_rnmc.py
@@ -79,12 +79,7 @@ class RNMC(PymatgenTest):
 
         initial_state_data = [(li_plus_mol_entry, 30), (ec_mol_entry, 30)]
 
-        run(
-            molecule_entries,
-            initial_state_data,
-            network_folder,
-            param_folder
-        )
+        run(molecule_entries, initial_state_data, network_folder, param_folder)
 
         os.system("rm -r " + network_folder)
         os.system("rm -r " + param_folder)

--- a/tests/stochastic/test_rnmc.py
+++ b/tests/stochastic/test_rnmc.py
@@ -83,10 +83,7 @@ class RNMC(PymatgenTest):
             molecule_entries,
             initial_state_data,
             network_folder,
-            param_folder,
-            4,
-            200,
-            1000,
+            param_folder
         )
 
         os.system("rm -r " + network_folder)


### PR DESCRIPTION
in rnmc.py, set rate constants for a reaction as follows:

```
max_rate = k T / h

default:
dG < 0: rate_coeff = max_rate
dG > 0: rate_coeff =  max_rate * exp(-dG / k T)

alternate:
dG < 0: rate_coeff = max_rate * exp(-constant_barrier/kT)
dG > 0: rate_coeff = max_rate * exp(-(constant_barrier+dG)/kT)

```
The alternate formula doesn't actually do anything if all rates are set by the formula. It comes in to play if specific rates are set in another way

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [x] I have run the tests locally and they passed.
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
