### PR TITLE
floating single_elem_interm_ignore

### DIFF
--- a/src/mrnet/network/reaction_generation.py
+++ b/src/mrnet/network/reaction_generation.py
@@ -42,7 +42,9 @@ class ReactionGenerator:
             reactions,
             _,
         ) = ReactionNetwork.identify_concerted_rxns_for_specific_intermediate(
-            entry, self.rn, [e.parameters["ind"] for e in self.rn.entries_list]
+            entry, self.rn,
+            mols_to_keep=[e.parameters["ind"] for e in self.rn.entries_list],
+            single_elem_interm_ignore=self.single_elem_interm_ignore
         )
 
         return_list = []
@@ -111,10 +113,14 @@ class ReactionGenerator:
     def __next__(self):
         return self.next_reaction()
 
-    def __init__(self, input_entries):
+    def __init__(self,
+                 input_entries,
+                 single_elem_interm_ignore=["C1", "H1", "O1", "Li1", "P1", "F1"],
+                 ):
 
         self.rn = ReactionNetwork.from_input_entries(input_entries)
         self.rn.build()
+        self.single_elem_interm_ignore = single_elem_interm_ignore
 
         # generator state
 

--- a/src/mrnet/stochastic/rnmc.py
+++ b/src/mrnet/stochastic/rnmc.py
@@ -709,6 +709,8 @@ def run(
     number_of_steps: int = 200,
     number_of_simulations: int = 1000,
     constant_barrier=None,
+    single_elem_interm_ignore=["C1", "H1", "O1", "Li1", "P1", "F1"],
+    alt_binary_location=None
 ) -> SimulationAnalyser:
     """
     procedure which takes a list of molecule entries + initial state and runs
@@ -716,7 +718,11 @@ def run(
     procedures.
     """
 
-    reaction_generator = ReactionGenerator(molecule_entries)
+    reaction_generator = ReactionGenerator(
+        molecule_entries,
+        single_elem_interm_ignore=single_elem_interm_ignore
+    )
+
     rnsd = SerializedReactionNetwork(
         reaction_generator,
         initial_state,
@@ -736,7 +742,16 @@ def run(
         number_of_simulations=number_of_simulations,
     )
 
-    os.system("RNMC " + network_folder + " " + param_folder)
+
+    # in the version of RNMC distrubuted with conda-forge (the default meson build) all
+    # debugging symbols are stripped, so if it segfaults, you need wade through assembly
+    # to figure out what happened. alt_binary_location lets you run with an alternative
+    # version of RNMC. Useful if you want to see explicit backtraces
+
+    if alt_binary_location is None:
+        os.system("RNMC" + " " + network_folder + " " + param_folder)
+    else:
+        os.system(alt_binary_location + " " + network_folder + " " + param_folder)
 
     simulation_analyzer = SimulationAnalyser(rnsd, network_folder)
 


### PR DESCRIPTION
Allow `single_elem_interm_ignore` to be specified in the end to end RNMC pipeline

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [ ] I have run the tests locally and they passed.
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
