### PR TITLE
Remove elementary reaction duplicates

### DIFF
--- a/src/mrnet/core/reactions.py
+++ b/src/mrnet/core/reactions.py
@@ -1074,7 +1074,8 @@ class IntermolecularReaction(Reaction):
                                 isomorphic1, _ = is_isomorphic(
                                     frags[1].graph, entry1.graph
                                 )
-                                if isomorphic1 and frozenset([entry0, entry1]) not in product_set and frozenset([entry1, entry0]) not in product_set:
+                                if isomorphic1 and frozenset([entry0, entry1]) not in product_set \
+                                and frozenset([entry1, entry0]) not in product_set:
                                     if determine_atom_mappings:
                                         rct_mp, prdts_mp = generate_atom_mapping_1_2(
                                             entry, [entry0, entry1], [edge]
@@ -1457,7 +1458,8 @@ class CoordinationBondChangeReaction(Reaction):
                             nonM_charge
                         ]:
                             isomorphic, _ = is_isomorphic(frag.graph, nonM_entry.graph)
-                            if isomorphic and frozenset([nonM_entry, M_entries[M_formula][M_charge]]) not in product_set:
+                            if isomorphic and frozenset([nonM_entry, M_entries[M_formula][M_charge]]) \
+                            not in product_set:
                                 this_m = M_entries[M_formula][M_charge]
 
                                 if determine_atom_mappings:

--- a/src/mrnet/core/reactions.py
+++ b/src/mrnet/core/reactions.py
@@ -1075,7 +1075,7 @@ class IntermolecularReaction(Reaction):
                                     frags[1].graph, entry1.graph
                                 )
                                 if isomorphic1 and frozenset([entry0, entry1]) not in product_set \
-                                and frozenset([entry1, entry0]) not in product_set:
+                                    and frozenset([entry1, entry0]) not in product_set:
                                     if determine_atom_mappings:
                                         rct_mp, prdts_mp = generate_atom_mapping_1_2(
                                             entry, [entry0, entry1], [edge]
@@ -1459,7 +1459,7 @@ class CoordinationBondChangeReaction(Reaction):
                         ]:
                             isomorphic, _ = is_isomorphic(frag.graph, nonM_entry.graph)
                             if isomorphic and frozenset([nonM_entry, M_entries[M_formula][M_charge]]) \
-                            not in product_set:
+                                not in product_set:
                                 this_m = M_entries[M_formula][M_charge]
 
                                 if determine_atom_mappings:

--- a/src/mrnet/core/reactions.py
+++ b/src/mrnet/core/reactions.py
@@ -1074,8 +1074,11 @@ class IntermolecularReaction(Reaction):
                                 isomorphic1, _ = is_isomorphic(
                                     frags[1].graph, entry1.graph
                                 )
-                                if isomorphic1 and frozenset([entry0, entry1]) not in product_set \
-                                    and frozenset([entry1, entry0]) not in product_set:
+                                if (
+                                    isomorphic1
+                                    and frozenset([entry0, entry1]) not in product_set
+                                    and frozenset([entry1, entry0]) not in product_set
+                                ):
                                     if determine_atom_mappings:
                                         rct_mp, prdts_mp = generate_atom_mapping_1_2(
                                             entry, [entry0, entry1], [edge]
@@ -1458,8 +1461,13 @@ class CoordinationBondChangeReaction(Reaction):
                             nonM_charge
                         ]:
                             isomorphic, _ = is_isomorphic(frag.graph, nonM_entry.graph)
-                            if isomorphic and frozenset([nonM_entry, M_entries[M_formula][M_charge]]) \
-                                not in product_set:
+                            if (
+                                isomorphic
+                                and frozenset(
+                                    [nonM_entry, M_entries[M_formula][M_charge]]
+                                )
+                                not in product_set
+                            ):
                                 this_m = M_entries[M_formula][M_charge]
 
                                 if determine_atom_mappings:

--- a/src/mrnet/core/reactions.py
+++ b/src/mrnet/core/reactions.py
@@ -749,7 +749,11 @@ class IntramolSingleBondChangeReaction(Reaction):
             if nx.is_weakly_connected(mg.graph):
                 for entry0 in entries[formula][Nbonds0][charge]:
                     isomorphic, node_mapping = is_isomorphic(entry0.graph, mg.graph)
-                    if isomorphic and node_mapping and entry0 not in entry0_set:
+                    if (
+                        isomorphic
+                        and node_mapping
+                        and entry0.entry_id not in entry0_set
+                    ):
                         if determine_atom_mappings:
                             rct_mp, prdt_mp = generate_atom_mapping_1_1(node_mapping)
                             r = cls(
@@ -765,7 +769,7 @@ class IntramolSingleBondChangeReaction(Reaction):
                             )
 
                         reactions.append(r)
-                        entry0_set.add(entry0)
+                        entry0_set.add(entry0.entry_id)
 
                         break
 
@@ -1076,8 +1080,10 @@ class IntermolecularReaction(Reaction):
                                 )
                                 if (
                                     isomorphic1
-                                    and frozenset([entry0, entry1]) not in product_set
-                                    and frozenset([entry1, entry0]) not in product_set
+                                    and frozenset([entry0.entry_id, entry1.entry_id])
+                                    not in product_set
+                                    and frozenset([entry1.entry_id, entry0.entry_id])
+                                    not in product_set
                                 ):
                                     if determine_atom_mappings:
                                         rct_mp, prdts_mp = generate_atom_mapping_1_2(
@@ -1096,8 +1102,12 @@ class IntermolecularReaction(Reaction):
                                         )
 
                                     reactions.append(r)
-                                    product_set.add(frozenset([entry0, entry1]))
-                                    product_set.add(frozenset([entry1, entry0]))
+                                    product_set.add(
+                                        frozenset([entry0.entry_id, entry1.entry_id])
+                                    )
+                                    product_set.add(
+                                        frozenset([entry1.entry_id, entry0.entry_id])
+                                    )
 
                                     break
                             break
@@ -1464,7 +1474,10 @@ class CoordinationBondChangeReaction(Reaction):
                             if (
                                 isomorphic
                                 and frozenset(
-                                    [nonM_entry, M_entries[M_formula][M_charge]]
+                                    [
+                                        nonM_entry.entry_id,
+                                        M_entries[M_formula][M_charge].entry_id,
+                                    ]
                                 )
                                 not in product_set
                             ):
@@ -1487,7 +1500,9 @@ class CoordinationBondChangeReaction(Reaction):
                                         [nonM_entry, this_m],
                                     )
                                 reactions.append(r)
-                                product_set.add(frozenset([nonM_entry, this_m]))
+                                product_set.add(
+                                    frozenset([nonM_entry.entry_id, this_m.entry_id])
+                                )
 
                                 break
 

--- a/src/mrnet/network/reaction_network.py
+++ b/src/mrnet/network/reaction_network.py
@@ -791,7 +791,7 @@ class ReactionNetwork(MSONable):
                 cost_from_start,
                 min_cost,
                 PRs,
-                generate=True,
+                generate=generate_test_files,
             )
 
             solved_PRs = copy.deepcopy(old_solved_PRs)

--- a/tests/core/test_reactions.py
+++ b/tests/core/test_reactions.py
@@ -321,7 +321,9 @@ class TestIntramolSingleBondChangeReaction(PymatgenTest):
 
         reaction_set = set()
         for reaction in reactions:
-            reaction_set.add(frozenset([reaction.reactant.entry_id,reaction.product.entry_id]))
+            reaction_set.add(
+                frozenset([reaction.reactant.entry_id, reaction.product.entry_id])
+            )
         self.assertEqual(len(reaction_set), 73)
 
         for r in reactions:
@@ -441,7 +443,15 @@ class TestIntermolecularReaction(PymatgenTest):
         self.assertEqual(len(reactions), 3029)
         reaction_set = set()
         for reaction in reactions:
-            reaction_set.add(frozenset([reaction.reactant.entry_id, reaction.product_0.entry_id, reaction.product_1.entry_id]))
+            reaction_set.add(
+                frozenset(
+                    [
+                        reaction.reactant.entry_id,
+                        reaction.product_0.entry_id,
+                        reaction.product_1.entry_id,
+                    ]
+                )
+            )
         self.assertEqual(len(reaction_set), 3029)
 
         for r in reactions:
@@ -575,7 +585,15 @@ class TestCoordinationBondChangeReaction(PymatgenTest):
 
         reaction_set = set()
         for reaction in reactions:
-            reaction_set.add(frozenset([reaction.reactant.entry_id, reaction.product_0.entry_id, reaction.product_1.entry_id]))
+            reaction_set.add(
+                frozenset(
+                    [
+                        reaction.reactant.entry_id,
+                        reaction.product_0.entry_id,
+                        reaction.product_1.entry_id,
+                    ]
+                )
+            )
         self.assertEqual(len(reaction_set), 48)
 
         for r in reactions:

--- a/tests/core/test_reactions.py
+++ b/tests/core/test_reactions.py
@@ -317,7 +317,12 @@ class TestIntramolSingleBondChangeReaction(PymatgenTest):
     def test_generate(self):
 
         reactions = IntramolSingleBondChangeReaction.generate(entries["RN"].entries)
-        self.assertEqual(len(reactions), 93)
+        self.assertEqual(len(reactions), 73)
+
+        reaction_set = set()
+        for reaction in reactions:
+            reaction_set.add(frozenset([reaction.reactant.entry_id,reaction.product.entry_id]))
+        self.assertEqual(len(reaction_set), 73)
 
         for r in reactions:
             # TODO (mjwen) this is never run for two reasons:
@@ -433,7 +438,11 @@ class TestIntermolecularReaction(PymatgenTest):
     def test_generate(self):
         reactions = IntermolecularReaction.generate(entries["RN"].entries)
 
-        self.assertEqual(len(reactions), 3673)
+        self.assertEqual(len(reactions), 3029)
+        reaction_set = set()
+        for reaction in reactions:
+            reaction_set.add(frozenset([reaction.reactant.entry_id, reaction.product_0.entry_id, reaction.product_1.entry_id]))
+        self.assertEqual(len(reaction_set), 3029)
 
         for r in reactions:
             if r.reactant.entry_id == entries["LiEC_RO"].entry_id:
@@ -562,7 +571,12 @@ class TestCoordinationBondChangeReaction(PymatgenTest):
     def test_generate(self):
 
         reactions = CoordinationBondChangeReaction.generate(entries["RN"].entries)
-        self.assertEqual(len(reactions), 50)
+        self.assertEqual(len(reactions), 48)
+
+        reaction_set = set()
+        for reaction in reactions:
+            reaction_set.add(frozenset([reaction.reactant.entry_id, reaction.product_0.entry_id, reaction.product_1.entry_id]))
+        self.assertEqual(len(reaction_set), 48)
 
         for r in reactions:
             if r.reactant.entry_id == entries["LiEC"].entry_id:

--- a/tests/network/test_reaction_network.py
+++ b/tests/network/test_reaction_network.py
@@ -41,12 +41,15 @@ class TestReactionGenerator(PymatgenTest):
         molecule_entries = loadfn(os.path.join(test_dir, "ronalds_MoleculeEntry.json"))
         reaction_generator = ReactionGenerator(molecule_entries)
 
+        reaction_set = set()
         counter = 0
 
         for reaction in reaction_generator:
+            reaction_set.add(frozenset(reaction[0]+reaction[1]))
             counter += 1
 
-        self.assertEqual(counter, 129)
+        self.assertEqual(counter, 119)
+        self.assertEqual(len(reaction_set), 106)
 
 
 class TestReactionPath(PymatgenTest):

--- a/tests/network/test_reaction_network.py
+++ b/tests/network/test_reaction_network.py
@@ -45,7 +45,7 @@ class TestReactionGenerator(PymatgenTest):
         counter = 0
 
         for reaction in reaction_generator:
-            reaction_set.add(frozenset(reaction[0]+reaction[1]))
+            reaction_set.add(frozenset(reaction[0] + reaction[1]))
             counter += 1
 
         self.assertEqual(counter, 119)


### PR DESCRIPTION
Uses sets and frozensets to avoid duplicate elementary reactions in the `_generate_one()` functions of `IntramolSingleBondChangeReaction`, `IntermolecularReaction`, and `CoordinationBondChangeReaction`. Tests modified to match the new number of unique reactions, but I manually confirmed that was also the number of unique reactions obtained before these changes. 