### PR TITLE
Change linear scaling to (I think) constant scaling for concerted reaction filtering

### DIFF
--- a/tests/network/test_reaction_generation.py
+++ b/tests/network/test_reaction_generation.py
@@ -93,7 +93,7 @@ class TestReactionGenerator(PymatgenTest):
         assert rxns_unfiltered == unfiltered_reference
 
         iter_filtered = ReactionIterator(
-            entries_box, single_elem_interm_ignore=[], filter_metal_coordination=True
+            entries_box, single_elem_interm_ignore=[], filter_concerted_metal_coordination=True
         )
         rxns_filtered = sorted([e for e in iter_filtered])
         filtered_reference = loadfn(os.path.join(test_dir, "filtered_rxns_sorted.json"))


### PR DESCRIPTION
Use a dictionary, defined in ReactionGenerator.__init__, to store all index: formula mappings. This (I think) will fix the linear scaling issue for concerted reaction filtering.